### PR TITLE
Disable Installdir Input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+## CUSTOM DEVELOPER ##
+pykern/
+config.pykern
+## These are generated after installation and are user-customized, therefore obselete for commits
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,10 @@ def setupInit():
     cls()
     print("PyKern Setup")
     print("The Terminal OS made on python for fun!")
-    print("Choose install directory:")
-    installdir = input()
+    print("Choosing a name for your install directory has been deprecated. It is set to pykern")
+    print("Press ENTER to continue")
+    input()
+    installdir = "pykern"
     print("[-] Creating config file...")
     configfile = open("config.pykern", "w")
     configfile.write(installdir)


### PR DESCRIPTION
Rest in peace, the ability to choose your own name for the installation directory. You will be missed.

This is for #1 

Yeah, for that, for better git efficiency. How's that for Source control management?